### PR TITLE
Remove inko-debug from package list

### DIFF
--- a/data/packages.yml
+++ b/data/packages.yml
@@ -4,8 +4,6 @@
 - owner: dusty-phillips
   name: inko-argparse
 - owner: dusty-phillips
-  name: inko-debug
-- owner: dusty-phillips
   name: inko-regex
 - owner: dusty-phillips
   name: inko-tui


### PR DESCRIPTION
I have archived the inko-debug repository, as it relied on the generic `std.fmt.Formatter` trait to do  its job, so porting it to 0.13 is not trivial.

I will probably move some of the debugging output to the inko-tui package, but I don't think the IndentedFormatter can reasonably ported. (It may be helpful to add some variation of IndentedFormatter to the std.fmt.Formatter class).