### PR TITLE
Fix typo

### DIFF
--- a/examples/errors.inko
+++ b/examples/errors.inko
@@ -30,6 +30,6 @@ class async Main {
 
     # We can also just unwrap the Ok value if we're
     # certain we'll never get an `Error` case:
-    div(10, 2).unwrap # => 10
+    div(10, 2).unwrap # => 5
   }
 }


### PR DESCRIPTION
As a Rubyist/Elixirist, this language looks interesting 🤗 

Just a small typo I stumbled upon:

10 / 2 == 5, not 10